### PR TITLE
Add tooltip for copy and delete buttons

### DIFF
--- a/components/StageTab.tsx
+++ b/components/StageTab.tsx
@@ -187,7 +187,7 @@ const StageTab = ({ handleChooseStage }: StageTabProps) => {
                   <IconButton onClick={handleOnCopyPrintEnv(o)} title="Copy Token">
                     <ContentCopyIcon />
                   </IconButton>
-                  <IconButton onClick={handleOnDeleteStage(o)}>
+                  <IconButton onClick={handleOnDeleteStage(o)} title="Delete Stage">
                     <DeleteIcon />
                   </IconButton>
                 </AccordionSummary>

--- a/components/StageTab.tsx
+++ b/components/StageTab.tsx
@@ -184,7 +184,7 @@ const StageTab = ({ handleChooseStage }: StageTabProps) => {
                       {`${o.vars == "1" ? "" : "s"}`}
                     </Typography>
                   </Box>
-                  <IconButton onClick={handleOnCopyPrintEnv(o)}>
+                  <IconButton onClick={handleOnCopyPrintEnv(o)} title="Copy Token">
                     <ContentCopyIcon />
                   </IconButton>
                   <IconButton onClick={handleOnDeleteStage(o)}>


### PR DESCRIPTION
Added tooltip for:
- handleOnCopyPrintEnv
- handleOnDeleteStage

Will look like:
![image](https://github.com/portunus-dev/portunus-ui/assets/11252951/884f5e88-2495-4552-a0fe-c7ab35bdb71b)
![image](https://github.com/portunus-dev/portunus-ui/assets/11252951/e7912215-1a75-485e-b793-ab784fd1fd41)
