### PR TITLE
[G2M] projects - Updated useEffect to use hard page reload to make full /all request to get updated data

### DIFF
--- a/hooks/project.ts
+++ b/hooks/project.ts
@@ -108,10 +108,14 @@ export const useProject = () => {
     editProjectExecuteRequest({ name: newName, project });
 
   useEffect(() => {
-    if (editProjectData) {
+    if (editProjectData && !editProjectError) {
+      console.log("Project edit successful. Dispatching state update and refreshing page...");
       envDispatch({ type: "editProject", payload: editProjectData });
+      window.location.reload();
+    } else if (editProjectError) {
+       console.error("Error during project edit request:", editProjectError);
     }
-  }, [editProjectData]);
+  }, [editProjectData, editProjectError, envDispatch]);
 
   return {
     PROJECT_FIELDS,


### PR DESCRIPTION
Problem:
Updating a project's name for the 1st time will do the correct project name update because the browser already has the proper value for the previous project name, but on the 2nd update for the same project (can be a possible scenario) the request will go but the `key` for the project name is still old, because browser still have the old data and the request will fail.

Solution:
I tried a couple of reactjs concepts but because I'm not too good with the same, I had to fall back with a simple solution where a page reload will update the new value in the browser's context - I know not a neat solution but have to go with this for now as a dirty fix.